### PR TITLE
Remove Key bindings for Fold & Unfold

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,16 +110,6 @@
         "when": "editorLangId == 'vso' && editorTextFocus"
       },
       {
-        "command": "editor.fold",
-        "key": "tab",
-        "when": "editorLangId == 'vso' && editorTextFocus"
-      },
-      {
-        "command": "editor.unfold",
-        "key": "shift+tab",
-        "when": "editorLangId == 'vso' && editorTextFocus"
-      },
-      {
         "command": "extension.scheduling",
         "key": "ctrl+alt+s",
         "when": "editorLangId == 'vso' && editorTextFocus"


### PR DESCRIPTION
These keybindings are uneccessary as VS Code provides <kbd>Ctrl+Shift+[ </kbd> for Fold and <kbd>Ctrl+Shift+] </kbd> for Unfold